### PR TITLE
Fixed bug #97

### DIFF
--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -176,7 +176,7 @@ module Watson
 			
 			# Generate full path since File doesn't care about the LOAD_PATH
 			# [review] - gsub uses (.?)+ to grab anything after lib (optional), better regex? 
-			_full_path = __dir__.gsub(/\/lib(.?)+/, '') + "/" + "assets/defaultConf"
+			_full_path = __dir__.gsub(%r!/lib/watson(.?)+!, '') + "/assets/defaultConf"
 			debug_print "Full path to defaultConf (in gem): #{ _full_path }\n"
 			
 			# Check to make sure we can access the default file


### PR DESCRIPTION
## Cause of bug

`__dir__.gsub(/\/lib(.?)+/, '')` is wrong regexp.
Therefore error occur when __dir__ contains 'lib' twice.

```
dir = '/Users/alpaca-tc/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/watson-ruby-34a011943c7d/lib/watson'

p dir.gsub(/\/lib(.?)+/, '') + "/" + "assets/defaultConf" 
# got => "/Users/alpaca-tc/.rbenv/versions/2.0.0-p247/assets/defaultConf"
# expected => "/Users/alpaca-tc/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/watson-ruby-34a011943c7d/assets/defaultConf"
```
