### PR TITLE
Fixes installation procedure as per README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ gem install watson-ruby
 
 Or you can clone this repo and install with Rake
 ```
-clone https://github.com/nhmood/watson-ruby.git .
+git clone https://github.com/nhmood/watson-ruby.git .
 cd watson-ruby
-rake 
+bundle install
+bundle exec rake 
 ```
   
 ## Usage


### PR DESCRIPTION
The installation procedure in the README
- missed the git command
- did not work if some of the gems are not
  yet installed on the machine.

Tested with rvm ruby 2.0.0/osx
