### PR TITLE
Don't raise an exception on binary files, see #89

### DIFF
--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -234,7 +234,13 @@ module Watson
 				# Find any comment line with [tag] - text (any comb of space and # acceptable)
 				# Using if match to stay consistent (with config.rb) see there for
 				# explanation of why I do this (not a good good one persay...)
-				_mtch = _line.match(/^[#{ _comment_type }+?\s+?]+\[(\w+)\]\s+-\s+(.+)/)
+				begin
+					_mtch = _line.match(/^[#{ _comment_type }+?\s+?]+\[(\w+)\]\s+-\s+(.+)/)
+				rescue ArgumentError
+					debug_print "#{_absolute_path}: Skipping file: #{$!}\n"
+					break
+				end
+
 				if !_mtch
 					debug_print "No valid tag found in line, skipping\n"
 					next


### PR DESCRIPTION
Instead ignore the file and debug_print the filename.
