### PR TITLE
Separate username from repo owner name for Bitbucket API access

### DIFF
--- a/lib/watson/bitbucket.rb
+++ b/lib/watson/bitbucket.rb
@@ -141,9 +141,9 @@ module Watson
 	
 			# No OAuth for Bitbucket yet so just store username in api for config
 			# This will let us just prompt for PW
-			config.bitbucket_api = _owner
+			config.bitbucket_api = _username
 			config.bitbucket_pw = _password	# Never gets written to file
-			config.bitbucket_repo = _repo
+			config.bitbucket_repo = "#{ _owner }/#{ _repo }"
 			debug_print " \n"
 
 			# All setup has been completed, need to update RC
@@ -176,7 +176,6 @@ module Watson
 				return false
 			end
 
-
 			# If we haven't obtained the pw from user yet, do it
 			if config.bitbucket_pw.empty?
 				# No OAuth for Bitbucket yet, gotta get user password in order to make calls :(
@@ -202,7 +201,7 @@ module Watson
 			# Get all open tickets (anything but resolved)
 			# Create options hash to pass to Remote::http_call 
 			# Issues URL for Bitbucket + SSL
-			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_api }/#{ config.bitbucket_repo }/issues?status=!resolved",
+			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_repo }/issues?status=!resolved",
 					:ssl        => true,
 					:method     => "GET",
 					:basic_auth => [config.bitbucket_api, config.bitbucket_pw],
@@ -233,7 +232,7 @@ module Watson
 			# Get all closed tickets
 			# Create options hash to pass to Remote::http_call 
 			# Issues URL for Bitbucket + SSL
-			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_api }/#{ config.bitbucket_repo }/issues?status=resolved",
+			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_repo }/issues?status=resolved",
 					:ssl        => true,
 					:method     => "GET",
 					:basic_auth => [config.bitbucket_api, config.bitbucket_pw],
@@ -340,7 +339,7 @@ module Watson
 			# Create option hash to pass to Remote::http_call
 			# Issues URL for GitHub + SSL
 			# No tag or label concept in Bitbucket unfortunately :(
-			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_api }/#{ config.bitbucket_repo }/issues",
+			opts = {:url        => "https://bitbucket.org/api/1.0/repositories/#{ config.bitbucket_repo }/issues",
 					:ssl        => true,
 					:method     => "POST",
 					:basic_auth => [config.bitbucket_api, config.bitbucket_pw],


### PR DESCRIPTION
Previously for Bitbucket repos, the username and the repository owner were assumed to be the same.
This patch brings the Bitbucket code in line with the Github code by storing `bitbucket_repo` as `owner/repo`, and making sure `bitbucket_api` is only used for authentication.

Unfortunately this change breaks all previous Bitbucket repo configurations.
