### PR TITLE
Add Objective C/C++ support

### DIFF
--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -383,7 +383,7 @@ module Watson
 				# [todo] - Add /* style comment
 				when ".cpp", ".cc", ".c", ".hpp", ".h",
 					 ".java", ".class", ".cs", ".js", ".php",
-					 ".m", ".mm"
+					 ".m", ".mm", ".go"
 					debug_print "Comment type is: //\n"
 					return "//"
 					

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -382,7 +382,8 @@ module Watson
 				# C / C++, Java, C#
 				# [todo] - Add /* style comment
 				when ".cpp", ".cc", ".c", ".hpp", ".h",
-					 ".java", ".class", ".cs", ".js", ".php"
+					 ".java", ".class", ".cs", ".js", ".php",
+					 ".m", ".mm"
 					debug_print "Comment type is: //\n"
 					return "//"
 					


### PR DESCRIPTION
Objective C/C++ files usually have .m and .mm extensions respectively.
