### PR TITLE
added -R option to less command to output raw control characters on osx

### DIFF
--- a/lib/watson/printer.rb
+++ b/lib/watson/printer.rb
@@ -129,7 +129,7 @@ module Watson
       if @config.use_less
         @output.close
         # [review] - Way of calling a native Ruby less?
-        system("less #{ @config.tmp_file }")
+        system("less -R #{ @config.tmp_file }")
         debug_print "File displayed with less, now deleting...\n"
         File.delete(@config.tmp_file)
       end


### PR DESCRIPTION
Without this option less asks you to open it even though it is a binary file. To avoid that and have it displayed correctly you need to add the `-R` option on mac (maybe even on other unix systems)

_BEFORE_

![bildschirmfoto 2013-11-23 um 16 27 44](https://f.cloud.github.com/assets/718617/1606683/de568126-5453-11e3-831a-d98706278666.png)

_AFTER_

![bildschirmfoto 2013-11-23 um 16 27 19](https://f.cloud.github.com/assets/718617/1606685/ec8c331c-5453-11e3-87b9-8699781e8265.png)
