### PR TITLE
Added .scala extension to list of known comment types in parser

### DIFF
--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -381,7 +381,7 @@ module Watson
           # [todo] - Add /* style comment
           when '.cpp', '.cc', '.c', '.hpp', '.h',
               '.java', '.class', '.cs', '.js', '.php',
-              '.m', '.mm', '.go'
+              '.m', '.mm', '.go', '.scala'
             debug_print "Comment type is: //\n"
             return '//'
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -29,6 +29,10 @@ describe Parser do
       it 'return correct extension (// for c/c++)' do
         @parser.get_comment_type('lib/watson.cpp').should eql '//'
       end
+
+      it 'return correct extension (// for scala)' do
+        @parser.get_comment_type('lib/watson.scala').should eql '//'
+      end
     end
 
     context 'unknown extension' do


### PR DESCRIPTION
The parser didn't include the `.scala` extension in the known comment formats.  I added this and a test (though this may be rather extraneous).

Not sure if this flies in the face of a more configurable approach that you amy take in the future but I thought it better to submit and get it rejected than to not submit at all.
