### PR TITLE
add support for sql extension with # and // for procedural languages

### DIFF
--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -406,7 +406,8 @@ module Watson
                '.py'      => ['#'],               # Python
                '.coffee'  => ['#'],               # CoffeeScript
                '.zsh'     => ['#'],               # Zsh
-               '.clj'     => [';;']               # Clojure
+               '.clj'     => [';;'] ,             # Clojure
+               '.sql'     => ['//', '#']          # SQL and PL types
              }
 
       loop do

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -407,7 +407,7 @@ module Watson
                '.coffee'  => ['#'],               # CoffeeScript
                '.zsh'     => ['#'],               # Zsh
                '.clj'     => [';;'] ,             # Clojure
-               '.sql'     => ['//', '#']          # SQL and PL types
+               '.sql'     => ['---', '//' ]       # SQL and PL types
              }
 
       loop do

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -406,8 +406,8 @@ module Watson
                '.py'      => ['#'],               # Python
                '.coffee'  => ['#'],               # CoffeeScript
                '.zsh'     => ['#'],               # Zsh
-               '.clj'     => [';;'] ,             # Clojure
-               '.sql'     => ['---', '//' ]       # SQL and PL types
+               '.clj'     => [';;'],              # Clojure
+               '.sql'     => ['---', '//', '#' ]  # SQL and PL types
              }
 
       loop do


### PR DESCRIPTION
adds comment searches for inside `sql` using `//` and `#` specifically for procedural languages.

example:

```
CREATE OR REPLACE FUNCTION ObjectId () RETURNS
VARCHAR AS $$
  var time = Number((Number(new Date()) / 1000).toFixed(0)).toString(16);

  var res = plv8.execute("SELECT md5(current_database())");
  var machineId = res[0].md5.substring(0, 6);

  // [todo] - get rid of this line
  plv8.elog(NOTICE, machineId);

  res = plv8.execute("SELECT pg_backend_pid()");
  var processId = Number(res[0].pg_backend_pid).toString(16);

  var rand = Math.floor(Math.random()*16777216).toString(16);

  return time + machineId + processId + rand;
$$ LANGUAGE plv8 IMMUTABLE STRICT;
```

thoughts?
