### PR TITLE
Allow the Bitbucket PW to be stored in .watsonrc

### DIFF
--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -382,6 +382,10 @@ module Watson
           @bitbucket_api = _line.chomp!
           debug_print "Bitbucket API: #{ @bitbucket_api }\n"
 
+        when "bitbucket_pw"
+          # Same as GitHub parse above
+          @bitbucket_pw = _line.chomp!
+          debug_print "Bitbucket PW: #{ @bitbucket_pw }\n"
 
         when "bitbucket_repo"
           # Same as GitHub repo parse above


### PR DESCRIPTION
This is obviously not secure, but I feel that people should not 
check in the watsonrc file anyways?
