### PR TITLE
Asana Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ bundle exec rake
 
 
 ## Recent Updates
+  - watson now supports [Asana](http://asana.com)
   - watson now supports [GitLab](http://gitlab.com)
   - [vim-unite-watson.vim](https://github.com/alpaca-tc/vim-unite-watson.vim) integrates watson right into vim!
   - watson now supports multiple export modes

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ If individual directories are passed with the -d (--dirs) flag, each will be par
 If watson is run without this parameter, the parsing depth is unlimited and will search through all subdirectories found.  
 
 
-### -r, --remote [GITHUB, BITBUCKET, GITLAB]
+### -r, --remote [GITHUB, BITBUCKET, GITLAB, ASANA]
 This parameter is used to both list currently established remotes as well as setup new ones.  
 If passed without any options, the currently established remotes will be listed.  
-If passed with a github, bitbucket, gitlab argument, watson will proceed to ask some questions to set up the corresponding remote.  
+If passed with a github, bitbucket, gitlab, asana argument, watson will proceed to ask some questions to set up the corresponding remote.
 
 
 ### -s, --show [ALL, CLEAN, DIRTY]
@@ -193,12 +193,16 @@ This supports wildcard type selecting by providing .filename (no * required)
 
 **[context_depth]** - This value determines how many lines of context should be grabbed for each issue when posting to a remote.  
 
-**[(github/bitbucket/gitlab)_api]** - If a remote is established, the API key for the corresponding remote is stored here.  
+**[(github/bitbucket/gitlab/asana)_api]** - If a remote is established, the API key for the corresponding remote is stored here.
 Currently, OAuth has yet to be implemented for Bitbucket so the Bitbucket username is stored here.  
 
 **[(github/bitbucket/gitlab)_repo]** - The repo name / path is stored here.  
 
 **[(github/gitlab)_endpoint]** - The endpoint in case of GitHub Enterprise of GitLab configuration.
+
+**[asana_project]** - The Asana project in case of Asana integration is stored here.
+
+**[asana_workspace]** - The Asana workspace in case of Asana integration is stored here.
 
 The remote related .watsonrc options shouldn't need to be edited manually, as they are automatically populated when the -r, --remote setup is called.  
 

--- a/lib/watson.rb
+++ b/lib/watson.rb
@@ -8,6 +8,7 @@ require_relative 'watson/remote'
 require_relative 'watson/github'
 require_relative 'watson/bitbucket'
 require_relative 'watson/gitlab'
+require_relative 'watson/asana'
 require_relative 'watson/version'
 
 module Watson

--- a/lib/watson/asana.rb
+++ b/lib/watson/asana.rb
@@ -4,8 +4,11 @@ module Watson
 
     class Asana
 
+      @end_point = "https://app.asana.com/api/1.0"
+      @formatter = nil
+
       # Debug printing for this class
-      DEBUG = false
+      DEBUG = true
 
       class << self
 
@@ -16,98 +19,604 @@ module Watson
 
         #############################################################################
         # Setup remote access to Asana
-        # Get Username, Workspace, Project, Password
+        # Get API Key, Workspace, Project
         def setup(config)
 
-          print_debug
-          print_access_attempt
-          if accepts_config_overwrite(config)
-            print_access_required
-            username = get_username_from_stdin
-            if username
-              token = get_oauth_token_from_asana(username)
-              if token
+          @formatter = Printer.new(config).build_formatter
 
-              end
-            end
-          end
+          # Identify method entry
+          debug_print "#{ self.class } : #{ __method__ }\n"
 
-        end
+          @formatter.print_status "+", GREEN
+          print BOLD + "Setting up Asana...\n" + RESET
 
-        def print_access_required
-          Printer.print_status "!", YELLOW
-          print BOLD + "Access to your Asana account required to make/update issues\n" + RESET
-          print "      See help or README for more details on Asana access\n\n"
-        end
-
-        def get_oauth_token_from_asana(username)
-          # [todo] get oauth token from asana
-
-        end
-
-        def get_username_from_stdin
-          # [todo] - Don't just check for blank password but invalid as well
-          # Poor mans username/password grabbing
-          print BOLD + "Username: " + RESET
-          _username = $stdin.gets.chomp
-          if _username.empty?
-            Printer.print_status "x", RED
-            print BOLD + "Input blank. Please enter your username!\n\n" + RESET
-          end
-          _username
-        end
-
-        def accepts_config_overwrite(config)
-          api_config = config.asana_api
-          workspace_config = config.asana_workspace
-          project_config = config.asana_project
-
-          unless api_config.empty? && workspace_config.empty? && project_config.empty?
-            Printer.print_status "!", RED
-            print BOLD + "Previous Asana Configuration is in RC, are you sure you want to overwrite?\n" + RESET
+          config_exists = config.asana_api.empty? && config.asana_workspace.empty? && config.asana_project.empty?
+          unless config_exists
+            @formatter.print_status "!", RED
+            print BOLD + "Previous Asana API is in RC, are you sure you want to overwrite?\n" + RESET
             print "      (Y)es/(N)o: "
 
             # Get user input
             _overwrite = $stdin.gets.chomp
             if ["no", "n"].include?(_overwrite.downcase)
-              print "\n"
-              Printer.print_status "x", RED
-              print BOLD + "Not overwriting current Asana configuration\n" + RESET
+              print "\n\n"
+              @formatter.print_status "x", RED
+              print BOLD + "Not overwriting current Asana config\n" + RESET
               return false
             end
           end
 
+          @formatter.print_status "!", YELLOW
+          print BOLD + "Asana API key required to make/update issues\n" + RESET
+          print "      See help or README for more details on Asana access\n\n"
+
+          print "\n"
+
+          print BOLD + "API Key: " + RESET
+          _api_key = $stdin.gets.chomp
+          if _api_key.empty?
+            @formatter.print_status "x", RED
+            print BOLD + "Input blank. Please enter your api key!\n\n" + RESET
+            return false
+          end
+
+          print BOLD + "Workspace: " + RESET
+          _workspace = $stdin.gets.chomp
+          if _workspace.empty?
+            @formatter.print_status "x", RED
+            print BOLD + "Input blank. Please enter your workspace!\n\n" + RESET
+            return false
+          end
+
+          print BOLD + "Project: " + RESET
+          _project = $stdin.gets.chomp
+          if _project.empty?
+            @formatter.print_status "x", RED
+            print BOLD + "Input blank. Please enter your project!\n\n" + RESET
+            return false
+          end
+
+          workspace_dict = get_workspaces(_api_key)
+
+          unless workspace_dict
+            @formatter.print_status "x", RED
+            print BOLD + "Asana setup failed\n" + RESET
+            return false
+          end
+
+          unless workspace_dict.include?(_workspace)
+            print "\n"
+            @formatter.print_status "x", RED
+            print BOLD + "Workspace doesn't exist\n" + RESET
+            print "      Check that the workspace name is correct\n"
+            print "      Possible workspaces: '#{ workspace_dict.keys.join('\', \'') }'\n\n"
+            return false
+          end
+
+          workspace_id = workspace_dict[_workspace]
+          project_dict = get_projects(_api_key, workspace_id)
+
+          unless project_dict
+            @formatter.print_status "x", RED
+            print BOLD + "Asana API Request failed\n" + RESET
+            return false
+          end
+
+          unless project_dict.include?(_project)
+            print "\n"
+            @formatter.print_status "x", RED
+            print BOLD + "Project doesn't exist within workspace '#{ _workspace }'\n" + RESET
+            print "      Check that the project name is correct\n"
+            print "      Possible projects: '#{ project_dict.keys.join('\', \'') }'\n\n"
+            return false
+          end
+
+          config.asana_api = _api_key
+          debug_print "Asana API Key updated to: #{ config.asana_api }\n"
+          config.asana_workspace = _workspace
+          debug_print "Asana Workspace updated to: #{ config.asana_workspace }\n"
+          config.asana_project = _project
+          debug_print "Asana Project updated to: #{ config.asana_project }\n"
+
+          # All setup has been completed, need to update RC
+          # Call config updater/writer from @config to write config
+          debug_print "Updating config with new Asana info\n"
+          config.update_conf("asana_api", "asana_workspace", "asana_project")
+
+          # Give user some info
+          print "\n"
+          @formatter.print_status "o", GREEN
+          print BOLD + "Asana successfully setup\n" + RESET
+          print "      Issues will now automatically be retrieved from Asana by default\n"
+          print "      Use -u, --update to post issues to Asana\n"
+          print "      See help or README for more details on GitHub/Bitbucket/Asana access\n\n"
+
           return true
+
+          # uzJXN8D.fsisV23hG7C3HF9bz4QuMsdh
+
+
+        end
+
+        ###########################################################
+        # Return all projects under the given api_key/workspace
+        def get_projects(_api_key, workspace_id)
+
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          projects_url = "#{ @end_point }/workspaces/#{ workspace_id}/projects"
+
+          opts = {
+              :url => projects_url,
+              :ssl => true,
+              :method => "GET",
+              :basic_auth => [_api_key, ""],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          if _resp.code != "200"
+            print "\n"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access project list\n" + RESET
+            print "       Status: #{ _resp.code } - #{ _resp.message }\n\n"
+            return false
+          else
+            print "\n"
+            @formatter.print_status "o", GREEN
+            print BOLD + "Successfully obtained project list\n\n" + RESET
+          end
+
+          project_list = _json["data"]
+          project_dict = {}
+          project_list.each { |x| project_dict[x["name"]] = x["id"] }
+          project_dict
+        end
+
+        ###########################################################
+        # Return all workspaces under the given API key
+        def get_workspaces(_api_key)
+
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          workspaces_url = "#{ @end_point }/workspaces"
+
+          opts = {
+              :url => workspaces_url,
+              :ssl => true,
+              :method => "GET",
+              :basic_auth => [_api_key, ""],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          if _resp.code != "200"
+            print "\n"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access workspace list with given credentials\n" + RESET
+            print "       Check that API key is correct\n"
+            print "       Status: #{ _resp.code } - #{ _resp.message }\n\n"
+            return false
+          else
+            print "\n"
+            @formatter.print_status "o", GREEN
+            print BOLD + "Successfully obtained workspace list\n\n" + RESET
+          end
+
+          workspace_list = _json["data"]
+          workspace_dict = {}
+          workspace_list.each { |x| workspace_dict[x["name"]] = x["id"] }
+          workspace_dict
         end
 
         ###########################################################
         # Get all remote Asana issues and store into Config container class
         def get_issues(config)
 
+          # Identify method entry
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          # Set up formatter for printing errors
+          # config.output_format should be set based on less status by now
+          @formatter = Printer.new(config).build_formatter
+
+          # Only attempt to get issues if API is specified
+          if config.asana_api.empty?
+            debug_print "No asana API found, this shouldn't be called...\n"
+            return false
+          end
+
+          _api_key = config.asana_api
+          _workspace = config.asana_workspace
+          _project = config.asana_project
+
+          task_records = get_tasks(_api_key, _project, _workspace)
+
+          unless task_records
+            config.asana_valid = false
+            return false
+          end
+
+          task_records.each do |issue|
+            # Skip this issue if it doesn't have watson md5 tag
+            _md5 = issue["notes"].match(/.*__md5__ : (\w+)\s.*/)
+            next if (_md5).nil?
+
+            # If it does, use md5 as hash key and populate values with our info
+            config.asana_issues[_md5[1]] = {
+                :title => issue["name"],
+                :id    => issue["id"],
+                :state => issue["completed"] # TODO: How to check status?
+            }
+          end
+
+          config.asana_valid = true
+
         end
 
         ###########################################################
-        # Post given issue to Asana workspace/project
+        # Return all tasks in given project/workspace
+        def get_tasks(_api_key, _project, _workspace)
+
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          workspace_id = get_workspace_id(_api_key, _workspace)
+
+          unless workspace_id
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to get workspace info from Asana API\n" + RESET
+            return false          end
+
+          project_id = get_project_identifier(_api_key, _project, workspace_id)
+
+          unless project_id
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to get project info from Asana API\n" + RESET
+            return false
+          end
+
+          tasks_url = "#{ @end_point }/projects/#{ project_id }/tasks?opt_fields=name,notes,completed&include_archived=true"
+
+          opts = {
+              :url => tasks_url,
+              :ssl => true,
+              :method => "GET",
+              :basic_auth => [_api_key, ""],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          # Check response to validate repo access
+          if _resp.code != "200"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access Asana API, key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+
+            debug_print "Asana invalid, setting config var\n"
+            #return false
+          end
+
+          _json["data"]
+
+        end
+
+        ###########################################################
+        # Return full record for a particular task
+        def get_task_record(_api_key, task_id)
+
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          task_url = "#{ @end_point }/tasks/#{ task_id }"
+
+          opts = {
+              :url => task_url,
+              :ssl => true,
+              :method => "GET",
+              :basic_auth => [_api_key, ""],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          if _resp.code != "200"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to get task, API key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+            return false
+          end
+
+          _json["data"]
+        end
+
+        ###########################################################
+        # Get project id given project and work space name
+        def get_project_identifier(_api_key, _project, workspace_id)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+          projects_dict = get_projects(_api_key, workspace_id)
+          unless projects_dict
+            return false
+          end
+          projects_dict[_project]
+        end
+
+        ###########################################################
+        # Get workspace id given workspace name
+        def get_workspace_id(_api_key, _workspace)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+          workspace_dict = get_workspaces(_api_key)
+          unless workspace_dict
+            return false
+          end
+          workspace_dict[_workspace]
+        end
+
+        ###########################################################
+        # Post given issue to Asana project
         def post_issue(issue, config)
 
+          # Identify method entry
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          # Set up formatter for printing errors
+          # config.output_format should be set based on less status by now
+          @formatter = Printer.new(config).build_formatter
+
+          # Only attempt to get issues if API is specified
+          if config.asana_api.empty?
+            debug_print "No asana API found, this shouldn't be called...\n"
+            return false
+          end
+
+          return false if config.asana_issues.key?(issue[:md5])
+          debug_print "#{issue[:md5]} not found in remote issues, posting\n"
+
+          _api_key = config.asana_api
+          _workspace = config.asana_workspace
+          _project = config.asana_project
+
+          workspace_id = get_workspace_id(_api_key, _workspace)
+
+          unless workspace_id
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to get workspace info from Asana API\n" + RESET
+            return false
+          end
+
+          tags = init_tags(config, _api_key, workspace_id)
+
+          unless tags
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to initialise tags\n" + RESET
+            return false
+          end
+
+          project_id = get_project_identifier(_api_key, _project, workspace_id)
+
+          unless project_id
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to get project info from Asana API\n" + RESET
+            return false
+          end
+
+          tasks_url = "#{ @end_point }/workspaces/#{ workspace_id }/tasks"
+
+          # Create the body text for the issue here, too long to fit nicely into opts hash
+          _body =
+              "__filename__ : #{ issue[:path] }\n" +
+              "__line #__ : #{ issue[:line_number] }\n" +
+              "__tag__ : #{ issue[:tag] }\n" +
+              "__md5__ : #{ issue[:md5] }\n\n" +
+              "#{ issue[:context].join }\n"
+
+          opts = {
+              :url => tasks_url,
+              :ssl => true,
+              :method => "POST",
+              :basic_auth => [_api_key, ""],
+              :data => [{"name" => issue[:title],
+                        "notes" => _body,
+                        "projects" => project_id}],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          unless _resp.code == "201"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access Asana API, key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+            return false
+          end
+
+          data = _json["data"]
+          new_task_id = data["id"]
+
+          debug_print "creating file tag"
+          file_tag = create_or_get_tag(_api_key,workspace_id,issue[:path])
+          debug_print "tagging with file tag <#{ file_tag }>"
+
+          if file_tag
+            file_tag_id = file_tag['id']
+            unless tag_task(_api_key, new_task_id, file_tag_id)
+              @formatter.print_status "!", RED
+              print BOLD + "Unable to tag with '#{ issue[:path] }'\n" + RESET
+            end
+          else
+            @formatter.print_status "!", RED
+            print BOLD + "Unable create tag '#{ issue[:path] }'\n" + RESET
+          end
+
+          debug_print "tagging with issue tag <#{ issue[:tag] }>"
+          issue_tag_id = tags[issue[:tag]]['id']
+          unless tag_task(_api_key, new_task_id, issue_tag_id)
+            @formatter.print_status "!", RED
+            print BOLD + "Unable to tag with '#{ issue[:tag] }'\n" + RESET
+          end
+
+          debug_print "tagging with watson tag"
+          watson_tag_id = tags['watson']['id']
+          unless tag_task(_api_key, new_task_id, watson_tag_id)
+            @formatter.print_status "!", RED
+            print BOLD + "Unable to tag with 'watson'\n" + RESET
+          end
+
+          # Parse response and append issue hash so we are up to date
+          config.asana_issues[issue[:md5]] = {
+              :title => data["name"],
+              :id    => data["id"],
+              :state => data["completed"]
+          }
+
+          true
+
         end
 
-    private :cancel_due_to_existing_config
+        ###########################################################
+        # Tags task with task_id with the tag specified by tag_id
+        def tag_task(_api_key, task_id, tag_id)
+          debug_print "#{ self.class } : #{ __method__ }\n"
 
+          tags_url = "#{ @end_point }/tasks/#{ task_id }/addTag"
 
+          opts = {
+              :url => tags_url,
+              :ssl => true,
+              :method => "POST",
+              :basic_auth => [_api_key, ""],
+              :data => [{"tag" => tag_id}],
+              :verbose => false
+          }
 
+          _json, _resp = Watson::Remote.http_call(opts)
 
+          unless _resp.code == "200"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access Asana API, key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+            return false
+          end
+
+          _json['data']
+
+        end
+
+        ###########################################################
+        # Returns hash, tag name => tag
+        def get_tags(_api_key, _workspace_id)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          tags_url = "#{ @end_point }/workspaces/#{ _workspace_id }/tags"
+
+          opts = {
+              :url => tags_url,
+              :ssl => true,
+              :method => "GET",
+              :basic_auth => [_api_key, ""],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          unless _resp.code == "200"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access Asana API, key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+            return false
+          end
+
+          # [review] - fancy ruby way of generating this hash?
+
+          _tags_dict = {}
+          _json['data'].each { |x| _tags_dict[x['name']] = x }
+          _tags_dict
+
+        end
+
+        ###########################################################
+        # Make sure base tags exist (tag_list + the watson tag), add them if not
+        def init_tags(config, _api_key, _workspace_id)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+          tags_to_check = config.tag_list.dup << 'watson'
+          create_and_get_tags(_api_key, _workspace_id, tags_to_check)
+        end
+
+        ###########################################################
+        # Adds 'tags_to_add' and returns full list of tags.
+        # The reason that this is combined into one method is that
+        # Asana do not actually 'create' the tag properly until
+        # it has been used to tag a task
+        def create_and_get_tags(_api_key, _workspace_id, tags_to_add)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          tags = get_tags(_api_key, _workspace_id)
+
+          unless tags
+            return false
+          end
+
+          debug_print "Checking that tags #{ tags_to_add } exist\n"
+          tags_to_create = tags_to_add - tags.keys
+          if tags_to_create
+            debug_print "Need to create tags #{ tags_to_create }\n"
+          end
+          tags_to_create.each do |tag_name|
+            tag = create_tag(_api_key, _workspace_id, tag_name)
+            unless tag
+              return false
+            end
+            tags[tag['name']] = tag
+          end
+
+          tags
+        end
+
+        ###########################################################
+        # Creates a tag in the given workspace
+        def create_tag(_api_key, _workspace_id, tag)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+
+          opts = {
+              :url => "#{ @end_point }/workspaces/#{ _workspace_id }/tags",
+              :ssl => true,
+              :method => "POST",
+              :basic_auth => [_api_key, ""],
+              :data => [{'name'=>tag}],
+              :verbose => false
+          }
+
+          _json, _resp = Watson::Remote.http_call(opts)
+
+          unless _resp.code == "201"
+            @formatter.print_status "x", RED
+            print BOLD + "Unable to access Asana API, key may be invalid\n" + RESET
+            print "      Consider running --remote (-r) option to regenerate key\n\n"
+            print "      Status: #{ _resp.code } - #{ _resp.message }\n"
+            return false
+          end
+
+          data = _json['data']
+
+          debug_print "Created tag '#{ tag }' with id #{ data['id'] } \n"
+
+          data
+
+        end
+
+        def create_or_get_tag(_api_key, _workspace_id, tag_name)
+          debug_print "#{ self.class } : #{ __method__ }\n"
+          tags = create_and_get_tags(_api_key, _workspace_id, [tag_name])
+          tags ? tags[tag_name] : false
+        end
 
       end
-
-        def print_access_attempt
-          Printer.print_status "+", GREEN
-          print BOLD + "Attempting to access Asana...\n" + RESET
-        end
-
-        def print_debug
-          debug_print "#{ self.class } : #{ __method__ }\n"
-        end
 
       end
 

--- a/lib/watson/asana.rb
+++ b/lib/watson/asana.rb
@@ -1,0 +1,116 @@
+module Watson
+
+  class Remote
+
+    class Asana
+
+      # Debug printing for this class
+      DEBUG = false
+
+      class << self
+
+        # [todo] - post issue to diff. project in same workspace depending on config?
+
+        # Include for debug_print
+        include Watson
+
+        #############################################################################
+        # Setup remote access to Asana
+        # Get Username, Workspace, Project, Password
+        def setup(config)
+
+          print_debug
+          print_access_attempt
+          if accepts_config_overwrite(config)
+            print_access_required
+            username = get_username_from_stdin
+            if username
+              token = get_oauth_token_from_asana(username)
+              if token
+
+              end
+            end
+          end
+
+        end
+
+        def print_access_required
+          Printer.print_status "!", YELLOW
+          print BOLD + "Access to your Asana account required to make/update issues\n" + RESET
+          print "      See help or README for more details on Asana access\n\n"
+        end
+
+        def get_oauth_token_from_asana(username)
+          # [todo] get oauth token from asana
+
+        end
+
+        def get_username_from_stdin
+          # [todo] - Don't just check for blank password but invalid as well
+          # Poor mans username/password grabbing
+          print BOLD + "Username: " + RESET
+          _username = $stdin.gets.chomp
+          if _username.empty?
+            Printer.print_status "x", RED
+            print BOLD + "Input blank. Please enter your username!\n\n" + RESET
+          end
+          _username
+        end
+
+        def accepts_config_overwrite(config)
+          api_config = config.asana_api
+          workspace_config = config.asana_workspace
+          project_config = config.asana_project
+
+          unless api_config.empty? && workspace_config.empty? && project_config.empty?
+            Printer.print_status "!", RED
+            print BOLD + "Previous Asana Configuration is in RC, are you sure you want to overwrite?\n" + RESET
+            print "      (Y)es/(N)o: "
+
+            # Get user input
+            _overwrite = $stdin.gets.chomp
+            if ["no", "n"].include?(_overwrite.downcase)
+              print "\n"
+              Printer.print_status "x", RED
+              print BOLD + "Not overwriting current Asana configuration\n" + RESET
+              return false
+            end
+          end
+
+          return true
+        end
+
+        ###########################################################
+        # Get all remote Asana issues and store into Config container class
+        def get_issues(config)
+
+        end
+
+        ###########################################################
+        # Post given issue to Asana workspace/project
+        def post_issue(issue, config)
+
+        end
+
+    private :cancel_due_to_existing_config
+
+
+
+
+
+      end
+
+        def print_access_attempt
+          Printer.print_status "+", GREEN
+          print BOLD + "Attempting to access Asana...\n" + RESET
+        end
+
+        def print_debug
+          debug_print "#{ self.class } : #{ __method__ }\n"
+        end
+
+      end
+
+  end
+
+end

--- a/lib/watson/command.rb
+++ b/lib/watson/command.rb
@@ -441,7 +441,7 @@ module Watson
 
       # Check the config for any remote entries (GitHub or Bitbucket) and print
       # We *should* always have a repo + API together, but API should be enough
-      if @config.github_api.empty? && @config.bitbucket_api.empty?
+      if @config.github_api.empty? && @config.bitbucket_api.empty? && @config.asana_api.empty?
         formatter.print_status "!", YELLOW
         print BOLD + "No remotes currently exist\n\n" + RESET
       end
@@ -461,6 +461,12 @@ module Watson
         print BOLD + "GitLab Repo : " + RESET + "#{ @config.gitlab_repo }\n\n" + RESET
       end
 
+      if !@config.asana_api.empty?
+        print BOLD + "Asana API Key : " + RESET + "#{ @config.asana_api }\n" + RESET
+        print BOLD + "Asana Workspace : " + RESET + "#{ @config.asana_workspace }\n" + RESET
+        print BOLD + "Asana Project : " + RESET + "#{ @config.asana_project }\n\n" + RESET
+      end
+
       # If github or bitbucket passed, setup
       # If just -r (0 args) do nothing and only have above printed
       # If more than 1 arg is passed, unrecognized, warn user
@@ -477,6 +483,10 @@ module Watson
         when "gitlab"
           debug_print "GitLab setup called from CL\n"
           Watson::Remote::GitLab.setup(@config)
+
+        when "asana"
+          debug_print "Asana setup called from CL\n"
+          Watson::Remote::Asana.setup(@config)
 
         end
       elsif args.length > 1

--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -158,8 +158,16 @@ module Watson
       @gitlab_issues   = Hash.new()
 
 
+      @asana_valid     = false
+      @asana_api       = ""
+      @asana_workspace = ""
+      @asana_project   = ""
+      @asana_issues    = Hash.new()
+
 
       @output_format = Watson::Formatters::DefaultFormatter
+
+
     end
 
 
@@ -187,6 +195,11 @@ module Watson
       unless @gitlab_api.empty? && @gitlab_repo.empty?
         Remote::GitLab.get_issues(self)
       end
+
+      unless @asana_api.empty? && @asana_project.empty? && @asana_workspace.empty?
+        Remote::Asana.get_issues(self)
+      end
+
     end
 
 
@@ -452,6 +465,20 @@ module Watson
           @gitlab_repo = _line.chomp!
           debug_print "GitLab Repo: #{ @gitlab_repo }\n"
 
+        when "asana_project"
+          @asana_project = _line.chomp!
+          debug_print "Asana Project: #{ @asana_project }\n"
+
+        when "asana_api"
+          @asana_api = _line.chomp!
+          debug_print "Asana API: #{ @asana_api }\n"
+
+        when "asana_workspace"
+          @asana_workspace = _line.chomp!
+          debug_print "Asana Workspace: #{ @asana_workspace }\n"
+
+
+
         else
           debug_print "Unknown tag found #{_section}\n"
         end
@@ -565,4 +592,9 @@ module Watson
 
   end
 end
+
+if __FILE__ == $0
+    @config = Watson::Config.new
+end
+
 

--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -65,6 +65,17 @@ module Watson
     # Hash to hold list of all Bitbucket issues associated with repo
     attr_accessor :bitbucket_issues
 
+    # Flag for whether Asana access is avaliable
+    attr_accessor :asana_valid
+    # Asana API Key
+    attr_accessor :asana_api
+    # Asana workspace
+    attr_accessor :asana_workspace
+    # Asana project within the workspace to place issues
+    attr_accessor :asana_project
+    # Hash to hold list of all Asana issues associated with repo
+    attr_accessor :asana_issues
+
 
     ###########################################################
     # Config initialization method to setup necessary parameters, states, and vars

--- a/lib/watson/formatters/default_formatter.rb
+++ b/lib/watson/formatters/default_formatter.rb
@@ -171,6 +171,15 @@ module Watson::Formatters
             MESSAGE
         end
 
+        if _AS = @config.asana_issues[issue[:md5]]
+          debug_print "Found #{ issue[:title]} in remote issues\n"
+          completed = _AS[:state]
+
+          cprint <<-MESSAGE.gsub(/^(\s+)/, '').chomp
+          #{BOLD}[#{RESET}#{completed ? GREEN : RED}#{BOLD}AS##{_AS[:id]}#{RESET}#{BOLD}]#{RESET}
+          MESSAGE
+        end
+
 
         cprint "\n"
       end

--- a/lib/watson/remote.rb
+++ b/lib/watson/remote.rb
@@ -129,7 +129,7 @@ module Watson
     def post_structure(structure, config, counter)
 
       # Return if remote isn't valid or both github and bitbucket aren't valid
-      return false if !config.remote_valid || (!config.github_valid && !config.bitbucket_valid && !config.gitlab_valid)
+      return false if !config.remote_valid || (!config.asana_valid && !config.github_valid && !config.bitbucket_valid && !config.gitlab_valid)
       formatter = Printer.new(config).build_formatter
 
       # Parse through entire structure and post issues to remote
@@ -140,6 +140,7 @@ module Watson
             Remote::GitHub.post_issue(issue, config)    if config.github_valid
             Remote::Bitbucket.post_issue(issue, config) if config.bitbucket_valid
             Remote::GitLab.post_issue(issue, config)    if config.gitlab_valid
+            Remote::Asana.post_issue(issue, config)     if config.asana_valid
             formatter.print_status "!", GREEN
             print BOLD + "Remote Posting Status: #{counter += 1} / #{config.issue_count}"
             print "\r"

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -98,6 +98,12 @@ describe Config do
       @config.bitbucket_repo.should == ''
       @config.bitbucket_issues.should == Hash.new()
 
+      @config.asana_valid.should be_false
+      @config.asana_api.should == ''
+      @config.asana_workspace.should == ''
+      @config.asana_project.should == ''
+      @config.asana_issues.should == Hash.new()
+
     end
   end
 


### PR DESCRIPTION
Really like Watson and wanted to be able to use it with [Asana](http://www.asana.com), a popular web-based project management tool that we use. I integrated this in the same fashion as with the other remotes. Setup involves specification of an API key obtained from Asana, a workspace and a project within that workspace. Issues are then pushed to the specified project and tagged with:
- fix/todo/review etc
- 'watson'
- filepath

e.g:

``` python
# blah.py

if __name__ == '__main__':
    # [todo] - a todo
    print 'Hello world'
```

![screen shot 2013-12-11 at 13 44 32](https://f.cloud.github.com/assets/1734057/1724224/142e4b92-626b-11e3-8b49-c0e8597e038c.png)

I think this would be useful to others also so may be worth pulling it in.

--Mike
