### PR TITLE
Fixed casting bug

### DIFF
--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -321,7 +321,7 @@ module Watson
         when "context_depth"
           # No need for regex on context value, command should read this in only as a #
           # Chomp to get rid of any nonsense
-          @context_depth = _line.chomp!
+          @context_depth = _line.chomp!.to_i
 
 
         when "parse_depth"


### PR DESCRIPTION
When executing `watson -c 2`, error occurred as follows.

``` sh
/Users/alpaca-tc/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/watson-ruby-1.5.0/lib/watson/parser.rb:284:in `+': String can't be coerced into Fixnum (TypeError)
        from /Users/alpaca-tc/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/watson-ruby-1.5.0/lib/watson/parser.rb:284:in `block in parse_file'
...
```
