### PR TITLE
Add support for `TAG: x` tag syntax

### DIFF
--- a/assets/examples/main.cpp
+++ b/assets/examples/main.cpp
@@ -2,11 +2,11 @@
 #include <cstdlib>
 #include <string>
 
-// [todo] - Find more Sherlock Holmes quotes
-// [todo] - Write Watson response function
+// TODO: Find more Sherlock Holmes quotes
+// todo: Write Watson response function
 // [todo] - Add debug mode with debug prints
 
-// [review] - Should I use char *argv[] or char **argv?
+// review: Should I use char *argv[] or char **argv?
 int main(int argc, char *argv[]){
 
   // [review] - Use namespace std to avoid std::String or not?

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -257,6 +257,7 @@ module Watson
           formatter = Printer.new(@config).build_formatter
           formatter.print_status "+", GREEN
           print "Unknown tag [#{ _tag }] found, ignoring\n"
+          print "      In #{_absolute_path}:#{_i}\n"
           print "      You might want to include it in your RC or with the -t/--tags flag\n"
           next
         end

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -209,7 +209,7 @@ module Watson
       # with a ~5% performance gain, but this would loose the warning about
       # unrecognized tags.
       _comment_regex = /
-        ^[[#{ _comment_type }]+?\s+?]+     # comment type
+        ^(?:\s*[#{ _comment_type }]+\s*)+  # comment type supports starting whitespace
         \[?(\w+)\]?                        # [tag], tag, or TAG syntax
         \s*[-:]                            # hyphen or colon
         \s+(.+)$                           # tag comment

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -208,8 +208,12 @@ module Watson
       # [review] - It is possible to embed the valid tags in the regexp,
       # with a ~5% performance gain, but this would loose the warning about
       # unrecognized tags.
-      _comment_regex = /^[[#{ _comment_type }]+?\s+?]+\[(\w+)\]\s+-\s+(.+)/
-
+      _comment_regex = /
+        ^[[#{ _comment_type }]+?\s+?]+     # comment type
+        \[?(\w+)\]?                        # [tag], tag, or TAG syntax
+        \s*[-:]                            # hyphen or colon
+        \s+(.+)$                           # tag comment
+      /x
 
       # Open file and read in entire thing into an array
       # Use an array so we can look ahead when creating issues later
@@ -245,7 +249,7 @@ module Watson
         end
 
         # Set tag
-        _tag = _mtch[1]
+        _tag = _mtch[1].downcase
 
         # Make sure that the tag that was found is something we accept
         # If not, skip it but tell user about an unrecognized tag


### PR DESCRIPTION
Hi there!

I've been trying to work watson into my daily workflow, but the major hangup was the tag syntax. All of our comments are in the `TAG: x` syntax, rather than watson's `[tag] - x`. This PR adds support for both and clarifies the comment regex. I hope you consider it!

Thanks!
