### PR TITLE
Add configurable tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# watson-ruby [![Gem Version](https://badge.fury.io/rb/watson-ruby.png)](http://badge.fury.io/rb/watson-ruby) [![Build Status](https://travis-ci.org/nhmood/watson-ruby.png?branch=master)](https://travis-ci.org/nhmood/watson-ruby) 
+# watson-ruby [![Gem Version](https://badge.fury.io/rb/watson-ruby.png)](http://badge.fury.io/rb/watson-ruby) [![Build Status](https://travis-ci.org/nhmood/watson-ruby.png?branch=master)](https://travis-ci.org/nhmood/watson-ruby)
 
 ### an inline issue manager
-[watson](http://goosecode.com/watson) ([mirror](http://nhmood.github.io/watson-ruby)) is a tool for creating and tracking bug reports, issues, and internal notes in code.  
+[watson](http://goosecode.com/watson) ([mirror](http://nhmood.github.io/watson-ruby)) is a tool for creating and tracking bug reports, issues, and internal notes in code.
 It is avaliable in two flavors, [watson-ruby](http://github.com/nhmood/watson-ruby) and [watson-perl](http://github.com/nhmood/watson-perl)
 
 ### See watson in action [here](http://goosecode.com/watson) ([mirror](http://nhmood.github.io/watson-ruby))
 ### See the RDoc documentation [here](http://goosecode.com/watson/ruby/doc/) ([mirror](http://nhmood.github.io/watson-ruby/ruby/doc/))
 
 ## Installation
-watson-ruby has been tested with **Ruby v2.0.0p247** and **RubyGems v2.0.3** (on **Arch Linux**)  
+watson-ruby has been tested with **Ruby v2.0.0p247** and **RubyGems v2.0.3** (on **Arch Linux**)
 watson-ruby requires the ```json``` gem
 
 ### From Repo
-watson-ruby is avaliable as a RubyGems ([link](https://rubygems.org/gems/watson-ruby)).  
+watson-ruby is avaliable as a RubyGems ([link](https://rubygems.org/gems/watson-ruby)).
 You can either download it directory from ```gem``` using
 ```
 gem install watson-ruby
@@ -37,11 +37,11 @@ bundle exec rake
 
 
 ## Usage
-For a quick idea of how to use watson, check out the [app demo](http://goosecode.com/watson)! ([mirror](http://nhmood.github.io/watson-ruby))  
-See below for a description of what all the command line arguments do.  
+For a quick idea of how to use watson, check out the [app demo](http://goosecode.com/watson)! ([mirror](http://nhmood.github.io/watson-ruby))
+See below for a description of what all the command line arguments do.
 
 ### Supported Languages
-If you see something missing from the list please either file an issue or  
+If you see something missing from the list please either file an issue or
 submit a pull request (comment parsing happens in **lib/watson/paser.rb**)
 
 - **C / C++**
@@ -106,111 +106,111 @@ watson home page: <http://goosecode.com/projects/watson>
 ### All file/directory/tag related parameters support relative as well as absolute paths.
 
 ### -c, --context-lines [LINES]
-This parameter specifies how many lines of context watson should include when posting issues to remote repos.  
-When this parameter is set from the command line, the .watsonrc config file is written with the value; the command line option effectively sets the default value for this feature in the current directory.  
-The default value is set to 15 (and can be found in the lib/watson/command.rb file).  
+This parameter specifies how many lines of context watson should include when posting issues to remote repos.
+When this parameter is set from the command line, the .watsonrc config file is written with the value; the command line option effectively sets the default value for this feature in the current directory.
+The default value is set to 15 (and can be found in the lib/watson/command.rb file).
 
 
 ### -d, --dirs [DIRS]
-This parameter specifies which directories watson should parse through.  
-It should be followed by a space separated list of directories that should be parsed.  
-If watson is run without this parameter, the current directory is parsed.  
+This parameter specifies which directories watson should parse through.
+It should be followed by a space separated list of directories that should be parsed.
+If watson is run without this parameter, the current directory is parsed.
 
 
 ### --debug [CLASS]
-This parameter enables debug prints for the specified class.  
-It should be followed by a space separated list of classes that should print debug messages.  
+This parameter enables debug prints for the specified class.
+It should be followed by a space separated list of classes that should print debug messages.
 The list of classes are found in `lib/watson`.
-If passed without arguments, debug prints in **ALL** classes of watson will be enabled.  
+If passed without arguments, debug prints in **ALL** classes of watson will be enabled.
 
 
 ### -f, --files [FILES]
-This parameter specifies which files watson should parse through.  
-It should be followed by a space separated list of files that should be parsed.  
+This parameter specifies which files watson should parse through.
+It should be followed by a space separated list of files that should be parsed.
 
 
 ### --format [PRINT, JSON, UNITE, SILENT]
-This parameter specifies how watson should output the issues that it finds.  
-If passed with `print`, the regular printing will occur, either to Unix less or STDOUT (depending on system).  
-If passed with `json`, the output will be in the form of JSON, and will be stored in `.watsonresults`.  
+This parameter specifies how watson should output the issues that it finds.
+If passed with `print`, the regular printing will occur, either to Unix less or STDOUT (depending on system).
+If passed with `json`, the output will be in the form of JSON, and will be stored in `.watsonresults`.
 
 - This particular option is useful if attempting to intergrate watson into other tools / platforms.
 
-If passed with `unite`, the output will be compatible with the unite.vim plugin  
+If passed with `unite`, the output will be compatible with the unite.vim plugin
 (see the **Unite** section below or visit [alpaca-tc/vim-unite-watson](https://github.com/alpaca-tc/vim-unite-watson.vim)
 
-If passed with `silent`, watson will have no output.  
+If passed with `silent`, watson will have no output.
 
-- This particular option is useful if remote posting to GitHub, Bitbucket, or GitLab is desired without the visual component of watson.  
+- This particular option is useful if remote posting to GitHub, Bitbucket, or GitLab is desired without the visual component of watson.
 - For example, you could set up a **git commit hook** to post issues to GitHub/Bitbucket/GitLab, but avoid the giant print out every time.
 
 
 ### -h, --help
-This parameter displays the list of avaliable options for watson.  
+This parameter displays the list of avaliable options for watson.
 
 
 ### -i, --ignore [IGNORES]
-This parameter specifies which files and directories watson should ignore when parsing.  
-It should be followed by a space separated list of files and/or directories to be ignored.  
-This parameter should be used as an opposite to -d/-f, when there are more files that should be parsed in a directory than should be ignored.  
+This parameter specifies which files and directories watson should ignore when parsing.
+It should be followed by a space separated list of files and/or directories to be ignored.
+This parameter should be used as an opposite to -d/-f, when there are more files that should be parsed in a directory than should be ignored.
 
 
 ### -p, --parse-depth [PARSE_DEPTH]
-This parameter specifies how deep watson should recursively parse directories.  
-The 'depth' is defined as how many levels deep from the top-most specified directory to parse.  
-If individual directories are passed with the -d (--dirs) flag, each will be parsed PARSE_DEPTH layers, regardless of their depth from the current directory.  
-If watson is run without this parameter, the parsing depth is unlimited and will search through all subdirectories found.  
+This parameter specifies how deep watson should recursively parse directories.
+The 'depth' is defined as how many levels deep from the top-most specified directory to parse.
+If individual directories are passed with the -d (--dirs) flag, each will be parsed PARSE_DEPTH layers, regardless of their depth from the current directory.
+If watson is run without this parameter, the parsing depth is unlimited and will search through all subdirectories found.
 
 
 ### -r, --remote [GITHUB, BITBUCKET, GITLAB, ASANA]
-This parameter is used to both list currently established remotes as well as setup new ones.  
-If passed without any options, the currently established remotes will be listed.  
+This parameter is used to both list currently established remotes as well as setup new ones.
+If passed without any options, the currently established remotes will be listed.
 If passed with a github, bitbucket, gitlab, asana argument, watson will proceed to ask some questions to set up the corresponding remote.
 
 
 ### -s, --show [ALL, CLEAN, DIRTY]
-This parameter is used to specify which types of files and entries are shown when watson is run.  
-If passed with the `clean` argument, only files that watson did *NOT* find issues in will be displayed.  
-If passed with the `dirty` argument, only files that watson *DID* find issues in will be displayed.  
-If passed with the `all` argument, watson will display all files, regardless of their issue status.  
-The default behavior of watson is the `all` option.  
+This parameter is used to specify which types of files and entries are shown when watson is run.
+If passed with the `clean` argument, only files that watson did *NOT* find issues in will be displayed.
+If passed with the `dirty` argument, only files that watson *DID* find issues in will be displayed.
+If passed with the `all` argument, watson will display all files, regardless of their issue status.
+The default behavior of watson is the `all` option.
 
 
 ### -t, --tags [TAGS]
-This parameter is used to specify which tags watson should look for when parsing.  
-The tag currently supports any regular character and number combination, no special (!@#$...) characters.  
+This parameter is used to specify which tags watson should look for when parsing.
+The tag currently supports any regular character and number combination, no special (!@#$...) characters.
 
 
 ### -u, --update
-This parameter is used to update remote repos with new issues.  
-watson **does not** post new issues by default therefore this parameter is required to push up to GitHub/Bitbucket/GitLab.  
-watson **does** pull issue status by default, therefore you will always be notified of resolved issues on GitHub/Bitbucket.  
+This parameter is used to update remote repos with new issues.
+watson **does not** post new issues by default therefore this parameter is required to push up to GitHub/Bitbucket/GitLab.
+watson **does** pull issue status by default, therefore you will always be notified of resolved issues on GitHub/Bitbucket.
 
 ### -v, --version
-This parameter displays the current version of watson you are running.  
+This parameter displays the current version of watson you are running.
 
 
 ## .watsonrc
-watson supports an RC file that allows for reusing commong settings without repeating command line arguments every time.  
+watson supports an RC file that allows for reusing commong settings without repeating command line arguments every time.
 
-The .watsonrc is placed in every directory that watson is run from as opposed to a unified file (in ~/.watsonrc for example). The thought process behind this is that each project may have a different set of folders to ignore, directories to search through, and tags to look for.  
-For example, a C/C++ project might want to look in src/ and ignore obj/ whereas a Ruby project might want to look in lib/ and ignore assets/.  
+The .watsonrc is placed in every directory that watson is run from as opposed to a unified file (in ~/.watsonrc for example). The thought process behind this is that each project may have a different set of folders to ignore, directories to search through, and tags to look for.
+For example, a C/C++ project might want to look in src/ and ignore obj/ whereas a Ruby project might want to look in lib/ and ignore assets/.
 
-A base `.watsonrc` is created in the users `$HOME` directory and used as the template for creating all subsequent config files.  
-Any changes made in the `$HOME/.watsonrc` will carry on towards new configs, but will **not** update previously created configs.  
-The `$HOME/.watsonrc` is directly copied, not merged, as to avoid confusion as to the source of config parameters.  
+A base `.watsonrc` is created in the users `$HOME` directory and used as the template for creating all subsequent config files.
+Any changes made in the `$HOME/.watsonrc` will carry on towards new configs, but will **not** update previously created configs.
+The `$HOME/.watsonrc` is directly copied, not merged, as to avoid confusion as to the source of config parameters.
 
-The .watsonrc file is fairly straightforward...  
-**[dirs]** - This is a newline separated list of directories to look in while parsing.  
+The .watsonrc file is fairly straightforward...
+**[dirs]** - This is a newline separated list of directories to look in while parsing.
 
-**[tags]** - This is a newline separated list of tags to look for while parsing.  
+**[tags]** - This is a newline separated list of tags to look for while parsing.
 
-**[ignore]** - This is a newline separated list of files / folders to ignore while parsing.    
-This supports wildcard type selecting by providing .filename (no * required)  
+**[ignore]** - This is a newline separated list of files / folders to ignore while parsing.
+This supports wildcard type selecting by providing .filename (no * required)
 
 **[context_depth]** - This value determines how many lines of context should be grabbed for each issue when posting to a remote.
 
-**[type]** - This field allows for custom filetype/comment associations without having to edit the gem itself.  
+**[type]** - This field allows for custom filetype/comment associations without having to edit the gem itself.
 The format of filetype entries should be
 ```
 ".type"   => ["comment1", "comment2"]
@@ -221,9 +221,9 @@ The format of filetype entries should be
 **[tag_format]** - Customize the tag format for your project. Defaults to `[TAG] - COMMENT`. "TAG" and "COMMENT" are required keywords.
 
 **[(github/bitbucket/gitlab/asana)_api]** - If a remote is established, the API key for the corresponding remote is stored here.
-Currently, OAuth has yet to be implemented for Bitbucket so the Bitbucket username is stored here.  
+Currently, OAuth has yet to be implemented for Bitbucket so the Bitbucket username is stored here.
 
-**[(github/bitbucket/gitlab)_repo]** - The repo name / path is stored here.  
+**[(github/bitbucket/gitlab)_repo]** - The repo name / path is stored here.
 
 **[(github/gitlab)_endpoint]** - The endpoint in case of GitHub Enterprise of GitLab configuration.
 
@@ -231,12 +231,12 @@ Currently, OAuth has yet to be implemented for Bitbucket so the Bitbucket userna
 
 **[asana_workspace]** - The Asana workspace in case of Asana integration is stored here.
 
-The remote related .watsonrc options shouldn't need to be edited manually, as they are automatically populated when the -r, --remote setup is called.  
+The remote related .watsonrc options shouldn't need to be edited manually, as they are automatically populated when the -r, --remote setup is called.
 
 ## unite.vim
 ### [vim-unite-watson.vim](https://github.com/alpaca-tc/vim-unite-watson.vim) by [alpaca-tc](http://github.com/alpaca-tc)
-**alpaca-tc** was kind enough to create a [unite.vim](https://github.com/Shougo/unite.vim) plugin to integrate with watson!  
-**unite.vim** allows you to create user interfaces within vim and lets you search and display any kind of information.  
+**alpaca-tc** was kind enough to create a [unite.vim](https://github.com/Shougo/unite.vim) plugin to integrate with watson!
+**unite.vim** allows you to create user interfaces within vim and lets you search and display any kind of information.
 The **unite-vim-watson.vim** plugin allows you to:
 
   - Generate a list of issues directly inside vim
@@ -248,18 +248,18 @@ If you use vim I ***definitely*** recommend using **vim-unite-watson.vim**, it w
 ### See it in action [here (GIF demo)](https://github.com/alpaca-tc/vim-unite-watson.vim)
 
 ## Special Thanks
-Special thanks to [@samirahmed](http://github.com/samirahmed) for his super Ruby help and encouraging the Ruby port!  
-Special thanks to [@eugenekolo](http://twitter.com/eugenekolo) [[email](eugenek@bu.edu)] for his super Perl help!  
-Special thanks to [@crowell](http://github.com/crowell) for testing out watson-ruby!  
+Special thanks to [@samirahmed](http://github.com/samirahmed) for his super Ruby help and encouraging the Ruby port!
+Special thanks to [@eugenekolo](http://twitter.com/eugenekolo) [[email](eugenek@bu.edu)] for his super Perl help!
+Special thanks to [@crowell](http://github.com/crowell) for testing out watson-ruby!
 
 ## FAQ
 - **Will inline issues get deleted if I close them on GitHub/Bitbucket/GitLab?**
   No, watson won't touch your source code, it will only inform you that issues have been closed remotely.
 
-- **Why Ruby?**  
+- **Why Ruby?**
   I wanted to learn Ruby and this seemed like a pretty decent project.
 
-- **Why is the Ruby version different from the Perl version?**  
-  The Ruby version was developed after the Perl version was made. Because of this, it was a lot easier to add on features that were thought of while/after making the Perl version as the plumbing was still being setup.  
-  With a combination of wanting to finish watson-ruby as well as laziness, some of the improvements that were added to watson-ruby *have yet* to be pulled back into watson-perl.  
+- **Why is the Ruby version different from the Perl version?**
+  The Ruby version was developed after the Perl version was made. Because of this, it was a lot easier to add on features that were thought of while/after making the Perl version as the plumbing was still being setup.
+  With a combination of wanting to finish watson-ruby as well as laziness, some of the improvements that were added to watson-ruby *have yet* to be pulled back into watson-perl.
   If you are interested in helping out or maintaining watson-perl let me know!

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ The format of filetype entries should be
 ".type"   => ["comment1", "comment2"]
 ".nhmood" => ["@@", "***"]
 ".cc"     => ["//"]
-```  
+```
+
+**[tag_format]** - Customize the tag format for your project. Defaults to `[TAG] - COMMENT`. "TAG" and "COMMENT" are required keywords.
 
 **[(github/bitbucket/gitlab/asana)_api]** - If a remote is established, the API key for the corresponding remote is stored here.
 Currently, OAuth has yet to be implemented for Bitbucket so the Bitbucket username is stored here.  

--- a/lib/watson/config.rb
+++ b/lib/watson/config.rb
@@ -18,6 +18,8 @@ module Watson
     attr_accessor :file_list
     # List of tags to look for when parsing
     attr_accessor :tag_list
+    # Tag format for look for
+    attr_accessor :tag_format
     # List of custom filetypes to accept
     attr_accessor :type_list
     # Number of directories to parse recursively
@@ -131,6 +133,8 @@ module Watson
       @tag_list     = Array.new()
       @type_list    = Hash.new()
       @issue_count  = 0
+
+      @tag_format = "[TAG] - COMMENT"
 
       # Remote options
       @remote_valid   = false
@@ -394,6 +398,9 @@ module Watson
           end
           debug_print "@tag_list --> #{ @tag_list }\n"
 
+        when "tag_format"
+          @tag_format = _line.chomp!
+          debug_print @tag_format
 
         when "type"
           # Regex to grab ".type" => ["param1", "param2"]

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -208,8 +208,15 @@ module Watson
       # [review] - It is possible to embed the valid tags in the regexp,
       # with a ~5% performance gain, but this would loose the warning about
       # unrecognized tags.
-      _comment_regex = /^[[#{ _comment_type }]+?\s+?]+\[(\w+)\]\s+-\s+(.+)/
+      _tag_format = Regexp.escape(@config.tag_format).gsub('\\ ', ' ')
+      _tag_format_regex = _tag_format
+                              .gsub("TAG", '(\w+)')
+                              .gsub("COMMENT", '(.+)')
+                              .gsub(' ' , '\s+')
 
+      _comment_regex = /^(?:\s*[#{_comment_type}]+\s*)+#{_tag_format_regex}/
+
+      debug_print "Comment regex: #{_comment_regex}\n"
 
       # Open file and read in entire thing into an array
       # Use an array so we can look ahead when creating issues later
@@ -245,7 +252,7 @@ module Watson
         end
 
         # Set tag
-        _tag = _mtch[1]
+        _tag = _mtch[1].downcase
 
         # Make sure that the tag that was found is something we accept
         # If not, skip it but tell user about an unrecognized tag

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -86,6 +86,8 @@ describe Config do
       @config.file_list.should == []
       @config.tag_list.should == []
 
+      @config.tag_format.should == "[TAG] - COMMENT"
+
       @config.remote_valid.should be_false
 
       @config.github_valid.should be_false


### PR DESCRIPTION
As per #235 conversation, this adds a more flexible, configurable tag format. Defaults to `[TAG] - COMMENT`
