### PR TITLE
Only print out in colour if STDOUT is sent to a tty.

### DIFF
--- a/lib/watson/printer.rb
+++ b/lib/watson/printer.rb
@@ -2,18 +2,35 @@ module Watson
   # Color definitions for pretty printing
   # Defined here because we need Global scope but makes sense to have them
   # in the printer.rb file at least
-  BOLD      = "\e[01m"
-  UNDERLINE = "\e[4m"
-  RESET     = "\e[00m"
+  if STDOUT.tty?
+      BOLD      = "\e[01m"
+      UNDERLINE = "\e[4m"
+      RESET     = "\e[00m"
 
-  GRAY      = "\e[38;5;0m"
-  RED       = "\e[38;5;1m"
-  GREEN     = "\e[38;5;2m"
-  YELLOW    = "\e[38;5;3m"
-  BLUE      = "\e[38;5;4m"
-  MAGENTA   = "\e[38;5;5m"
-  CYAN      = "\e[38;5;6m"
-  WHITE     = "\e[38;5;7m"
+      GRAY      = "\e[38;5;0m"
+      RED       = "\e[38;5;1m"
+      GREEN     = "\e[38;5;2m"
+      YELLOW    = "\e[38;5;3m"
+      BLUE      = "\e[38;5;4m"
+      MAGENTA   = "\e[38;5;5m"
+      CYAN      = "\e[38;5;6m"
+      WHITE     = "\e[38;5;7m"
+  else
+      # Hack: use null strings if not printing to screen.
+      # [todo] - have this as a configuration/command-line option?
+      BOLD      = ""
+      UNDERLINE = ""
+      RESET     = ""
+
+      GRAY      = ""
+      RED       = ""
+      GREEN     = ""
+      YELLOW    = ""
+      BLUE      = ""
+      MAGENTA   = ""
+      CYAN      = ""
+      WHITE     = ""
+  end
 
   # Printer class that handles all formatting and printing of parsed dir/file structure
   class Printer


### PR DESCRIPTION
I find it useful to dump the issues into a text file or send through a pipe.  The pretty printing formatting is, in those cases, rather annoying.  A reasonable default (in my opinion) is to only enable pretty printing if the standard output is sent to a tty. 
