### PR TITLE
Added support for OCaml source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ submit a pull request (comment parsing happens in **lib/watson/paser.rb**)
 - **HTML**
 - **SASS SCSS**
 - **Haskell**
+- **OCaml**
 - **Bash / Zsh**
 - **Ruby**
 - **Perl**

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -29,6 +29,8 @@ module Watson
         '.php'     => ['//', '/*', '#'],   # PHP
         '.m'       => ['//', '/*'],        # ObjectiveC
         '.mm'      => ['//', '/*'],
+        '.ml'      => ['(*', '(**'],       # OCaml
+        '.mli'     => ['(*', '(**'],       # OCaml
         '.go'      => ['//', '/*'],        # Go(lang)
         '.scala'   => ['//', '/*'],        # Scala
         '.erl'     => ['%%', '%'],         # Erlang


### PR DESCRIPTION
What the caption says, I made it track `.ml` (OCaml source) and `.mli` (OCaml interface) files.
