### PR TITLE
Add support for BlitzMax

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ submit a pull request (comment parsing happens in **lib/watson/paser.rb**)
 - **Emacslisp**
 - **LaTex**
 - **Handlebars**
+- **BlitzMax**
 
 
 ## Command line arguments

--- a/lib/watson/parser.rb
+++ b/lib/watson/parser.rb
@@ -58,7 +58,8 @@ module Watson
         '.d'       => ['//','/*'],         # D
         '.tex'     => ['%'],               # LaTex
         '.hbs'     => ['{{!--'],           # Handlebars
-        '.twig'    => ['{#']               # Twig
+        '.twig'    => ['{#'],              # Twig
+        '.bmx'     => ['\'']               # BlitzMax
     }.freeze
 
 


### PR DESCRIPTION
Adds the BlitzMax file extension ".bmx" and single line comment type "'" (single quote).
